### PR TITLE
fixed margings

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,10 +194,10 @@
     </div>
 
     <div
-      class="container mx-auto w-[210mm] border px-[9mm] py-[13.5mm] print:w-full print:max-w-full print:border-0"
+      class="container mx-auto w-[210mm] border px-[8.45mm] py-[13.5mm] print:w-full print:max-w-full print:border-0"
     >
       <!-- Display QR Code Labels -->
-      <ol class="grid grid-cols-7 gap-x-[2.5mm]">
+      <ol class="grid grid-cols-7 gap-x-[2.55mm]">
         <template x-for="label in labels">
           <li
             class="flex h-[10mm] w-[25.4mm] items-center border-[0.5mm] p-[0.5mm] odd:border-blue-500 even:border-red-300"


### PR DESCRIPTION
This change should fix the horizontal misalignment.

Based on commit 7aeeba0, I figured two issues with the actual spacings:

1. The exact spacing between fields is not 2.5mm but 2.55mm.
2. The total row width exeeds the page width (9mm left margin + 7x25.4mm field + 6x2.5(5)mm space + 9mm right margin > 210mm), which effectively squeezes the boxes a tiny bit to fit the page margins.

Solution:
- Setting the box spacing (gap-x) to 2.55mm, which exactly matches the official Avery template.
- Reducing the left & right margin so everything fits in the row without squeezing. With 2.55mm spacing the left+right margin must be reduced to 8.45mm, so everything adds up to the page with of 210mm.
