### PR TITLE
Add button to set next batch start number

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,12 @@
           </div>
         </div>
         <button
+          @click.prevent="setNextBatchStartNumber()"
+          class="w-full rounded-lg bg-gray-500 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-gray-600 focus:outline-none focus:ring-4 focus:ring-blue-300 sm:w-auto"
+        >
+          Next Batch
+        </button>
+        <button
           @click.prevent="generateLabels()"
           class="w-full rounded-lg bg-blue-700 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-800 focus:outline-none focus:ring-4 focus:ring-blue-300 sm:w-auto"
         >
@@ -284,6 +290,9 @@
           },
           init() {
             this.generateLabels();
+          },
+          setNextBatchStartNumber() {
+            this.startNumber = parseInt(this.startNumber, 10) + 7 * 27;
           },
         };
       }


### PR DESCRIPTION
This adds a button that increases the start number to the next batch's start number. I found this to be useful when creating multiple label pages in a row.