### PR TITLE
Verify Avery L4731REV-25 label dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,10 +194,10 @@
     </div>
 
     <div
-      class="container mx-auto w-[210mm] border px-[8.45mm] py-[13.5mm] print:w-full print:max-w-full print:border-0"
+      class="container mx-auto w-[210mm] border px-[8.6mm] py-[13.5mm] print:w-full print:max-w-full print:border-0"
     >
       <!-- Display QR Code Labels -->
-      <ol class="grid grid-cols-7 gap-x-[2.55mm]">
+      <ol class="grid grid-cols-7 gap-x-[2.5mm]">
         <template x-for="label in labels">
           <li class="h-[10mm] w-[25.4mm]">
             <div


### PR DESCRIPTION
Update horizontal padding from 8.45mm to 8.6mm and gap from 2.55mm to 2.5mm to match official Label Planet LP189/25 specifications for Avery L4731REV-25 compatible labels.