### PR TITLE
fix: correct Avery label format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ Single-page application using AlpineJS for reactivity. Key structure in `index.h
 
 - **Print styling**: Uses CSS `@page` rule for A4 paper with zero margins (requires Chrome/Chromium)
 
-- **Label format**: Hardcoded for Avery L4731REV-25 labels (see specifications below)
+- **Label format**: Hardcoded for Avery L4731 labels (see specifications below)
 
-## Avery L4731REV-25 Label Specifications
+## Avery L4731 Label Specifications
 
 Page: A4 (210mm × 297mm)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Users are encouraged to validate the output, especially the positioning of the l
 
 The application currently supports the following label formats:
 
-- Avery L4731REV-25 (See [UK shop](https://www.avery.co.uk/product/mini-multipurpose-labels-l4731rev-25), [DE shop](https://www.avery-zweckform.com/produkt/universal-etiketten-l4731rev-25))
+- Avery L4731 (See [UK shop](https://www.avery.co.uk/product/mini-multipurpose-labels-l4731rev-25), [DE shop](https://www.avery-zweckform.com/produkt/universal-etiketten-l4731rev-25))
 
 ### Limitations
 
@@ -23,7 +23,7 @@ The application currently has the following limitations:
 
 - The application is currently only available in English.
   This is considered a non-issue, as the application is designed to be self-explanatory.
-- The application currently only supports the Avery L4731REV-25 label format.
+- The application currently only supports the Avery L4731 label format.
   Contributions for additional label formats are welcome.
 - The application only supports Google Chrome and Chromium-based browsers, such as Microsoft Edge. And partially Firefox.
   This limitation is due to the use of the [CSS `@page` rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@page) for printing.

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           This tool generates QR code labels for the
           <abbr title="Archive Serial Number">ASN</abbr> feature. You can
           generate labels for up to 189 documents at once. The labels are
-          formatted to <strong>fit on Avery L4731REV-25 labels</strong>.
+          formatted to <strong>fit on Avery L4731 labels</strong>.
         </p>
 
         <p>


### PR DESCRIPTION
While using this template-based QR code label generator, I noticed that the Avery label format was referenced as _L4731REV-25_.

_L4731REV-25_ is a specific format variant that includes the package size.
However, the actual label layout is identical across all variants, e.g.:

- _L4731REV-10_
- _L4731REV-25_
- _L4731REV-65_

To avoid confusion and make it clear that the template applies to all _L4731_ variants, this pull request updates the reference to the generic _L4731_ format.

There are no functional changes — this is purely a clarification and correctness fix.

Thanks for maintaining the project, and feel free to let me know if you’d prefer a different wording or approach!